### PR TITLE
rework ptr receiver methods per comment in Provision()

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -27,7 +27,8 @@ import (
 )
 
 // GetClassForVolume locates storage class by persistent volume
-func (p awsS3Provisioner) getClassForBucketClaim(obc *v1alpha1.ObjectBucketClaim) (*storageV1.StorageClass, error) {
+func (p *awsS3Provisioner) getClassForBucketClaim(obc *v1alpha1.ObjectBucketClaim) (*storageV1.StorageClass, error) {
+
         if p.clientset == nil {
                 return nil, fmt.Errorf("Cannot get kube client")
         }
@@ -61,6 +62,7 @@ func getSecretName(parms map[string]string) (string, string) {
 func (p *awsS3Provisioner) credsFromSecret(c *kubernetes.Clientset, ns, name string) error {
 	secret, err := c.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
+		// TODO: some kind of exponential backoff and retry...
 		return fmt.Errorf("unable to get Secret \"%s/%s\" with error %v", ns, name, err)
 	}
 


### PR DESCRIPTION
My current thinking on how to use pointer receivers vs. value receivers -- also see `Provision` top comment:
Provision() is a value method, and as such, all `p` fields set in Provision are not visible after it returns. However Provision needs to set many fields in its receiver and uses helper methods to do this. There was a method call stack where `(value) Provision` calls `(value) A` which calls `(ptr) B` and B sets receiver fields. In this case the changes made by `B` are not visible to `Provision` due to method `A` being a value method.

This pr implements all methods (directs and indirect) called by Provision to be pointer methods so that there is no method call stack where a leaf methods cannot set the receiver seen by `Provision`.

@screeley44  @copejon 